### PR TITLE
Bug/1 escape arrays

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,9 +13,9 @@ A clear and concise description of what the bug is.
 
 Component  | Version
 ---------- | -------
-Zsh Escape | da39a3ee5e6b4b0d3255bfef95601890afd80709 (git hash)
+Zsh Escape | da39a3ee5e6b4b0d3255bfef95601890afd80709 (`git rev-parse HEAD`)
 OS | Windows 10
-Zsh | zsh 5.0.6 (i686-pc-cygwin) (`zsh --version`)
+Zsh | zsh 5.5.1 (i686-pc-cygwin) (`zsh --version`)
 
 **Steps To Reproduce**
 
@@ -27,10 +27,8 @@ cd $dir
 ```
 2. Run:
 ```zsh
-zsh-escape.zsh -r -d bad-script.zsh
+zsh-escape.zsh report bad-script.zsh
 ```
-
-Include the `-d|--debug` option when reporting a bug.
 
 **Expected Behaviour**
 

--- a/bin/test.zsh
+++ b/bin/test.zsh
@@ -7,4 +7,5 @@ set -e
 export PATH="$PATH:$ZSH_ESCAPE_BIN_DIR/tush:$ZSH_ESCAPE_BIN_DIR/zsh-escape"
 
 cd "$ZSH_ESCAPE_BIN_DIR/../test"
+tush-check "TESTS.md"
 tush-check "$ZSH_ESCAPE_BIN_DIR/../README.md"

--- a/bin/zsh-escape/zsh-escape.gawk
+++ b/bin/zsh-escape/zsh-escape.gawk
@@ -91,8 +91,9 @@ function fix_print(char) {
           #  ${name:/pattern/repl}
           #  ${name:offset}
           #  ${name:offset:length}
+          # FIXME: Add better array support. They are quite complicated.
           # See http://zsh.sourceforge.net/Doc/Release/Expansion.html#Parameter-Expansion
-          where = match(tail, /\$([*@#?$!_]|[+#^=~]?[a-zA-Z0-9_]*|[a-zA-Z0-9_]*([-+=?#%:]|:[-+=?#|*^]|::=|##|%%|:^^)[a-zA-Z0-9_]*|\{.*}|\(.*\))/)
+          where = match(tail, /\$([*@#?$!_]|[+#^=~]?[a-zA-Z0-9_]*(\[[^]]*\])?|[a-zA-Z0-9_]*([-+=?#%:]|:[-+=?#|*^]|::=|##|%%|:^^)[a-zA-Z0-9_]*|\{.*}|\(.*\))/)
           if (where) {
             var = substr(tail, RSTART, RLENGTH)
             i = i + RLENGTH - 1

--- a/bin/zsh-escape/zsh-escape.zsh
+++ b/bin/zsh-escape/zsh-escape.zsh
@@ -28,7 +28,7 @@ function exec_gawk() {
       exec 3> "$tmp_file"
       exec 4< "$tmp_file"
       rm "$tmp_file"
-      gawk -f zsh-escape.gawk "${args[@]}" "$file" >&3
+      gawk -f "$ZSH_ESCAPE_DIR/zsh-escape.gawk" "${args[@]}" "$file" >&3
       exec 3>&-
       cat <&4 > "$file"
       exec 4>&-

--- a/test/TESTS.md
+++ b/test/TESTS.md
@@ -1,5 +1,14 @@
 # Tests
 
-```sh
+## Arrays
 
+### Arrays must be escaped
+
+```sh
+$ cat unescaped-array-simple.zsh
+| echo $commands[git]
+$ zsh-escape.zsh report unescaped-array-simple.zsh
+| 1 : echo $commands[git]
+| - Unescaped variable: $commands[git]
+| - Found an unescaped variable
 ```

--- a/test/unescaped-array-simple.zsh
+++ b/test/unescaped-array-simple.zsh
@@ -1,0 +1,1 @@
+echo $commands[git]


### PR DESCRIPTION
Adds limited support for escaping arrays. I'm not sure exactly how arrays can be used in the more complex parameter expansion cases. More examples are needed.

Fixes #1.