### PR TITLE
Fix missing parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ $ cat unescaped-test-simple.zsh
 |   echo "FALSE"
 | fi
 $ zsh-escape.zsh report unescaped-test-simple.zsh
-| 1 : if [[ $FOO == false ]]; then
+| 1: if [[ $FOO == false ]]; then
 | - Unescaped parameter expansion: $FOO
 | - Found 1 unescaped expansion
-| 2 :   echo "FALSE"
-| 3 : fi
+| 2:   echo "FALSE"
+| 3: fi
 ```
 
 This shows that it found an unescaped variable `$FOO`.

--- a/test/TESTS.md
+++ b/test/TESTS.md
@@ -6,9 +6,11 @@
 
 ```sh
 $ zsh-escape.zsh report unescaped-array-simple.zsh
-| 1 : echo $commands[git]
+| 1: echo $commands[git]
 | - Unescaped parameter expansion: $commands[git]
 | - Found 1 unescaped expansion
+$ zsh-escape.zsh fix unescaped-array-simple.zsh
+| echo "$commands[git]"
 ```
 
 ## Arithmetic Evaluation
@@ -17,15 +19,19 @@ $ zsh-escape.zsh report unescaped-array-simple.zsh
 
 ```sh
 $ zsh-escape.zsh report escape-arithmetic-expansion.zsh
-| 1 : i=1 && echo $(( $i + 1 ))
+| 1: i=1 && echo $(( $i + 1 ))
 | - Unescaped arithmetic expansion: $(( $i + 1 ))
 | - Found 1 unescaped expansion
+$ zsh-escape.zsh fix escape-arithmetic-expansion.zsh
+| i=1 && echo "$(( $i + 1 ))"
 ```
 
 ### Arithmetic evaluation must not be escaped
 
 ```sh
 $ zsh-escape.zsh report exclude-arithmetic-evaluation.zsh
-| 1 : i=0 && if (( $i + 1 )); then echo true; else echo false; fi
+| 1: i=0 && if (( $i + 1 )); then echo true; else echo false; fi
 | - All expansions are escaped
+$ zsh-escape.zsh fix exclude-arithmetic-evaluation.zsh
+| i=0 && if (( $i + 1 )); then echo true; else echo false; fi
 ```


### PR DESCRIPTION
#7 introduced a bug where parentheses would be missing when using the `fix` command. This fixes that and updates the tests to catch it.